### PR TITLE
Git migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.04 PINS="bin_prot.114.06+90:https://github.com/talex5/bin_prot.git#cuekeeper mirage-conduit:3.0.1 irmin.0.10.1:https://github.com/talex5/irmin.git#cuekeeper"
+  - OCAML_VERSION=4.05 PINS="bin_prot.113.33.00+4.05:https://github.com/talex5/bin_prot.git#113.33.00+4.05 irmin.0.10.1:https://github.com/talex5/irmin.git#cuekeeper"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.04 PINS="bin_prot.114.06+90:https://github.com/talex5/bin_prot.git#cuekeeper mirage-conduit:3.0.1"
+  - OCAML_VERSION=4.04 PINS="bin_prot.114.06+90:https://github.com/talex5/bin_prot.git#cuekeeper mirage-conduit:3.0.1 irmin.0.10.1:https://github.com/talex5/irmin.git#cuekeeper"

--- a/irmin-indexeddb.opam
+++ b/irmin-indexeddb.opam
@@ -14,6 +14,7 @@ depends: [
   "js_of_ocaml" {>= "3.0"}
   "js_of_ocaml-lwt"
   "js_of_ocaml-ppx"
+  "git" {= "1.7.1"}
   "lwt"
 ]
 build: [

--- a/irmin-indexeddb.opam
+++ b/irmin-indexeddb.opam
@@ -7,7 +7,7 @@ license: "ISC"
 homepage: "https://github.com/talex5/irmin-indexeddb"
 bug-reports: "https://github.com/talex5/irmin-indexeddb/issues"
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.5.0"}
   "base64" {>= "3.0.0"}
   "irmin" {>= "0.10.0" & < "0.11.0"}
   "cstruct" {>= "1.7.0"}

--- a/lib/dune
+++ b/lib/dune
@@ -3,4 +3,4 @@
  (name irmin_indexeddb)
  (wrapped false)
  (preprocess (pps js_of_ocaml-ppx))
- (libraries lwt irmin js_of_ocaml js_of_ocaml-lwt base64))
+ (libraries lwt irmin git irmin.git js_of_ocaml js_of_ocaml-lwt base64))

--- a/lib/iridb_js_api.ml
+++ b/lib/iridb_js_api.ml
@@ -18,7 +18,7 @@ class type versionChangeEvent = object
   inherit Dom_html.event
 
   method oldVersion : int Js.readonly_prop
-  method newVersion : int Js.readonly_prop
+  method newVersion : int Js.readonly_prop Js.Opt.t
 end
 class type ['a] errorEvent = object
   inherit ['a] Dom.event

--- a/lib/iridb_lwt.ml
+++ b/lib/iridb_lwt.ml
@@ -60,9 +60,10 @@ let make db_name ~version ~init =
     print_endline "Waiting for other IndexedDB users to close their connections before upgrading schema version.";
     Js._true
   );
-  request##.onupgradeneeded := Dom.handler (fun _event ->
+  request##.onupgradeneeded := Dom.handler (fun event ->
     try
-      init request##.result;
+      let old_version = event##.oldVersion in
+      init ~old_version request##.result;
       Js._true
     with ex ->
       (* Firefox throws the exception away and returns AbortError instead, so save it here. *)

--- a/lib/iridb_lwt.mli
+++ b/lib/iridb_lwt.mli
@@ -12,7 +12,7 @@ type store_name
 
 val store_name : string -> store_name
 
-val make : db_name -> version:int -> init:(db_upgrader -> unit) -> db Lwt.t
+val make : db_name -> version:int -> init:(old_version:int -> db_upgrader -> unit) -> db Lwt.t
 (** Connect to database [db_name]. If it doesn't yet exist or is for an older version, calls [init] to initialise it first. *)
 
 val close : db -> unit

--- a/lib/irmin_IDB.ml
+++ b/lib/irmin_IDB.ml
@@ -11,18 +11,26 @@ let err_not_found n =
 let db_name_key =
   Irmin.Private.Conf.(key "indexedDB.db_name" string "Irmin")
 
-let ao = Iridb_lwt.store_name "ao"
-let rw = Iridb_lwt.store_name "rw"
+let ao = Iridb_lwt.store_name "ao_git"
+let rw = Iridb_lwt.store_name "rw_git"
 
-let version = 2
+let ao_old = Iridb_lwt.store_name "ao"
+let rw_old = Iridb_lwt.store_name "rw"
+
+let version = 3
 let connect db_name =
   Iridb_lwt.make db_name ~version ~init:(fun ~old_version upgrader ->
     match old_version with
     | 0 ->
-        Iridb_lwt.create_store upgrader ao;
-        Iridb_lwt.create_store upgrader rw;
+      Iridb_lwt.create_store upgrader ao_old;
+      Iridb_lwt.create_store upgrader rw_old;
+      Iridb_lwt.create_store upgrader ao;
+      Iridb_lwt.create_store upgrader rw;
+    | 2 ->
+      Iridb_lwt.create_store upgrader ao;
+      Iridb_lwt.create_store upgrader rw;
     | _ ->
-        failwith "Attempt to upgrade from unknown schema version!"
+      failwith "Attempt to upgrade from unknown schema version!"
   )
 
 module RO (K: Irmin.Hum.S) (V: Tc.S0) = struct
@@ -51,6 +59,17 @@ module RO (K: Irmin.Hum.S) (V: Tc.S0) = struct
     Lwt_list.iter_p (fun (k, v) -> fn (K.of_hum k) (return (Tc.read_string (module V) v)))
 end
 
+module AO_old (K: Irmin.Hash.S) (V: Tc.S0) = struct
+  include RO(K)(V)
+
+  let create config =
+    let db_name = Irmin.Private.Conf.get config db_name_key in
+    connect db_name >>= fun idb ->
+    return (Iridb_lwt.store idb ao_old)
+
+  let add _t _value = failwith "AO_old: read-only!"
+end
+
 module AO (K: Irmin.Hash.S) (V: Tc.S0) = struct
   include RO(K)(V)
 
@@ -65,7 +84,7 @@ module AO (K: Irmin.Hash.S) (V: Tc.S0) = struct
     Iridb_lwt.set t (K.to_hum k) v >|= fun () -> k
 end
 
-module RW (K: Irmin.Hum.S) (V: Tc.S0) = struct
+module RW_old (K: Irmin.Hum.S) (V: Tc.S0) = struct
   module W = Irmin.Private.Watch.Make(K)(V)
   module R = RO(K)(V)
 
@@ -73,6 +92,48 @@ module RW (K: Irmin.Hum.S) (V: Tc.S0) = struct
 
   type t = {
     r : R.t;
+    watch : W.t;
+  }
+
+  let create config =
+    let db_name = Irmin.Private.Conf.get config db_name_key in
+    let watch = W.create () in
+    connect db_name >>= fun idb ->
+    let r = Iridb_lwt.store idb rw_old in
+    return { watch; r }
+
+  let update _t _k _value = failwith "RW_old: update: read-only!"
+
+  let remove _t _k = failwith "RW_old: remove: read-only!"
+
+  let compare_and_set _t _k ~test:_ ~set:_ = failwith "RW_old: compare_and_set: read-only!"
+
+  let watch t ?init cb =
+    W.watch t.watch ?init cb
+
+  let unwatch t w =
+    W.unwatch t.watch w
+
+  let watch_key t key ?init cb =
+    W.watch_key t.watch key ?init cb
+
+  let iter t = R.iter t.r
+  let mem t = R.mem t.r
+  let read t = R.read t.r
+  let read_exn t = R.read_exn t.r
+  type value = R.value
+  type key = R.key
+end
+
+module RW (K: Irmin.Hum.S) (V: Irmin.Hash.S) = struct
+  module W = Irmin.Private.Watch.Make(K)(V)
+
+  type key = K.t
+  type value = V.t
+  type watch = W.watch
+
+  type t = {
+    r : Iridb_lwt.store;
     watch : W.t;
     prefix : string;
     notifications : Iridb_html_storage.t;
@@ -88,6 +149,28 @@ module RW (K: Irmin.Hum.S) (V: Tc.S0) = struct
     let r = Iridb_lwt.store idb rw in
     return { watch; r; prefix; notifications; listener = None }
 
+  let string_of_hash x = Cstruct.to_string (V.to_raw x)
+  let hash_of_string x = V.of_raw (Cstruct.of_string x)
+
+  let read t k =
+    Iridb_lwt.get t.r (K.to_hum k) >|= function
+    | None -> None
+    | Some s -> Some (hash_of_string s)
+
+  let read_exn t key =
+    read t key >>= function
+    | Some v -> return v
+    | None -> err_not_found "read"
+
+  let mem t k =
+    Iridb_lwt.get t.r (K.to_hum k) >|= function
+    | None -> false
+    | Some _ -> true
+
+  let iter t fn =
+    Iridb_lwt.bindings t.r >>=
+    Lwt_list.iter_p (fun (k, v) -> fn (K.of_hum k) (return (hash_of_string v)))
+
   let ref_listener t =
     match t.listener with
     | None ->
@@ -95,7 +178,7 @@ module RW (K: Irmin.Hum.S) (V: Tc.S0) = struct
           Iridb_html_storage.watch t.notifications ~prefix:t.prefix (fun key value ->
             let subkey = tail key (String.length t.prefix) in
             let ir_key = K.of_hum subkey in
-            let value = value >|?= Tc.read_string (module V) in
+            let value = value >|?= hash_of_string in
             async (fun () -> W.notify t.watch ir_key value)
           ) in
         t.listener <- Some (l, 1)
@@ -116,14 +199,14 @@ module RW (K: Irmin.Hum.S) (V: Tc.S0) = struct
     (* Notify other tabs *)
     begin match new_value with
     | None -> Iridb_html_storage.remove t.notifications (t.prefix ^ K.to_hum k)
-    | Some v -> Iridb_html_storage.set t.notifications (t.prefix ^ K.to_hum k) (Tc.write_string (module V) v)
+    | Some v -> Iridb_html_storage.set t.notifications (t.prefix ^ K.to_hum k) (string_of_hash v)
     end;
     (* Notify this tab *)
     W.notify t.watch k new_value
 
   let update t k value =
     (* Log.warn "Non-atomic update called!"; *)
-    Tc.write_string (module V) value
+    string_of_hash value
     |> Iridb_lwt.set t.r (K.to_hum k) >>= fun () ->
     notify t k (Some value)
 
@@ -136,9 +219,9 @@ module RW (K: Irmin.Hum.S) (V: Tc.S0) = struct
     let pred old =
       match old, test with
       | None, None -> true
-      | Some old, Some expected -> Tc.read_string (module V) old |> V.equal expected
+      | Some old, Some expected -> hash_of_string old |> V.equal expected
       | _ -> false in
-    let new_value = set >|?= Tc.write_string (module V) in
+    let new_value = set >|?= string_of_hash in
     Iridb_lwt.compare_and_set t.r (K.to_hum k) ~test:pred ~new_value >>= function
     | true -> notify t k set >|= fun () -> true
     | false -> return false
@@ -154,16 +237,183 @@ module RW (K: Irmin.Hum.S) (V: Tc.S0) = struct
   let watch_key t key ?init cb =
     ref_listener t;
     W.watch_key t.watch key ?init cb
-
-  let iter t = R.iter t.r
-  let mem t = R.mem t.r
-  let read t = R.read t.r
-  let read_exn t = R.read_exn t.r
-  type value = R.value
-  type key = R.key
 end
 
 let config db_name = Irmin.Private.Conf.singleton db_name_key db_name
 
-module Make (C: Irmin.Contents.S) (T: Irmin.Ref.S) (H: Irmin.Hash.S) =
-  Irmin.Make(AO)(RW)(C)(T)(H)
+(* From irmin-git *)
+module Digest (H: Irmin.Hash.S): Git.SHA.DIGEST = struct
+  (* FIXME: lots of allocations ... *)
+  let cstruct buf = Git.SHA.of_raw (Cstruct.to_string (H.to_raw (H.digest buf)))
+  let string str = cstruct (Cstruct.of_string str)
+  let length = Cstruct.len @@ H.to_raw (H.digest (Cstruct.of_string ""))
+end
+
+module Make (C: Irmin.Contents.S) (T: Irmin.Ref.S) (H: Irmin.Hash.S) = struct
+  (* We could just replace this with [Irmin.Make], but we want things in Git format so
+     that we can sync with real Git repositories. *)
+
+  module X = struct
+    module D = Digest(H)
+    module Value_IO = Git.Value.IO(D)(Git.Inflate.None)
+
+    module GitContents = struct
+      (* Serialises Git objects (e.g. [Blob "foo"]) using the Git format (e.g. "blob 3\0foo").
+         This means that they get the same hash that they would have got with the real Git. *)
+
+      type t = Git.Value.t
+      let equal = Git.Value.equal
+      let hash = Git.Value.hash
+      let compare = Git.Value.compare
+      let read = Value_IO.input
+      let to_string x =
+        let b = Buffer.create 1024 in
+        Value_IO.add b x;
+        Buffer.contents b
+      let write x cs =
+        let x = to_string x in
+        let l = String.length x in
+        Cstruct.blit_from_string x 0 cs 0 l;
+        Cstruct.shift cs l
+      let size_of x = to_string x |> String.length
+      let of_json _ = failwith "of_json"
+      let to_json _ = failwith "to_json"
+    end
+
+    (* AO store for Git.Value.t objects *)
+    module Git_store = struct
+      (* Slight mismatch here, because we provide an Irmin API not a Git one *)
+      module Raw = AO(H)(GitContents)
+
+      type t = Raw.t
+
+      let create = Raw.create
+
+      let hash_of_digest d =
+        Git.SHA.to_raw d |> Cstruct.of_string |> H.of_raw
+
+      let digest_of_hash hash =
+        H.to_raw hash |> Cstruct.to_string |> Git.SHA.of_raw
+
+      let read t d =
+        Raw.read t (hash_of_digest d)
+
+      let mem t d =
+        Raw.mem t (hash_of_digest d)
+
+      let write t v =
+        Raw.add t v >|= digest_of_hash
+
+      let contents t =
+        let results = ref [] in
+        Raw.iter t (fun k v ->
+            v >>= fun v ->
+            results := (digest_of_hash k, v) :: !results;
+            return ()
+          ) >|= fun () ->
+        !results
+
+      module Digest = D
+    end
+
+    module Y = Irmin_git.Irmin_value_store(Git_store)(C)(H)
+    include Irmin.Make_ext(struct
+        module Contents = Irmin.Contents.Make(Y.Contents)
+        module Node = Y.Node
+        module Commit = Y.Commit
+        module Ref = struct
+          module Key = T
+          module Val = H
+          include RW (T)(H)
+        end
+        module Slice = Irmin.Private.Slice.Make(Contents)(Node)(Commit)
+        module Sync = Irmin.Private.Sync.None(Commit.Key)(T)
+        module Repo = struct
+          type t = {
+            ao: Git_store.t;
+            rw: Ref.t;
+          }
+          let ref_t t = t.rw
+          let commit_t t = t.ao
+          let node_t t = t.ao
+          let contents_t t = t.ao
+
+          let create config =
+            Git_store.create config >>= fun ao ->
+            Ref.create config       >>= fun rw ->
+            Lwt.return { ao; rw }
+        end
+      end)
+  end
+
+  (* Don't know why we need to hide [slice] here - OCaml 4.05 compiler bug? *)
+  include (X : module type of X with type slice := X.slice and module Repo := X.Repo)
+  type slice = X.slice
+
+  (* Migration from Irmin 0.10 format to Git format. *)
+  module Old = Irmin.Make(AO_old)(RW_old)(C)(T)(H)
+  module Topo = Graph.Topological.Make(Old.History)
+
+  module Repo = struct
+    include X.Repo
+
+    let migrate_content t ~old c =
+      Old.Private.Contents.read_exn (Old.Private.Repo.contents_t old) c >>=
+      Private.Contents.add (Private.Repo.contents_t t)
+
+    let rec migrate_tree t ~old tree =
+      Old.Private.Node.read_exn (Old.Private.Repo.node_t old) tree >>= fun tree ->
+      Old.Private.Node.Val.alist tree |> Lwt_list.map_s (function
+          | s, `Contents c -> migrate_content t ~old c >|= fun c -> s, `Contents c
+          | s, `Node dir -> migrate_tree t ~old dir >|= fun dir -> s, `Node dir
+        ) >>= fun alist ->
+      let tree = Private.Node.Val.create alist in
+      Private.Node.add (Private.Repo.node_t t) tree
+
+    let lwt_opt_map f = function
+      | None -> Lwt.return_none
+      | Some x -> f x >|= fun y -> Some y
+
+    let create config =
+      create config >>= fun t ->
+      (* Upgrade to Git format, if needed *)
+      master Irmin.Task.none t >>= fun master ->
+      head (master ()) >>= function
+      | Some _ -> Lwt.return t          (* The new Git-format store is ready *)
+      | None ->
+        (* Either this is a new deployment or we're upgrading from an older version.
+           Try a migration. *)
+        Old.Repo.create config >>= fun old ->
+        Old.master Irmin.Task.none old >>= fun old_master ->
+        let old_master = old_master () in
+        Old.head old_master >>= function
+        | None -> Lwt.return t          (* New deployment *)
+        | Some old_head ->
+          (* Migration needed *)
+          Old.history old_master >>= fun history ->
+          let commits = Topo.fold (fun n acc -> n :: acc) history [] |> List.rev in
+          let n_commits = List.length commits in
+          let replacements = Hashtbl.create n_commits in
+          let old_commits = Old.Private.Repo.commit_t old in
+          let new_commits = Private.Repo.commit_t t in
+          let i = ref 0 in
+          commits |> Lwt_list.iter_s (fun c ->
+              if !i mod 100 = 0 then Printf.printf "Migrating commit %d/%d\n%!" !i n_commits;
+              incr i;
+              Old.Private.Commit.read_exn old_commits c >>= fun cv ->
+              let tree = Old.Private.Commit.Val.node cv in
+              let parents = Old.Private.Commit.Val.parents cv |> List.map (Hashtbl.find replacements) in
+              let task = Old.Private.Commit.Val.task cv in
+              lwt_opt_map (migrate_tree t ~old) tree >>= fun tree ->
+              let nc = Private.Commit.Val.create task ?node:tree ~parents in
+              Private.Commit.add new_commits nc >>= fun new_id ->
+              Hashtbl.add replacements c new_id;
+              Lwt.return_unit
+            ) >>= fun () ->
+          let new_head = Hashtbl.find replacements old_head in
+          print_endline "All commits migrated.";
+          Private.Ref.compare_and_set (Private.Repo.ref_t t) ~test:None T.master ~set:(Some new_head) >>= fun ok ->
+          if not ok then failwith "Failed to set new head in DB migration!";
+          Lwt.return t
+  end
+end

--- a/lib/irmin_IDB.mli
+++ b/lib/irmin_IDB.mli
@@ -3,14 +3,9 @@
 
 (** An Irmin backend that stores data in an IndexedDB. *)
 
-(* [config dn_name] store all values in the given IndexedDB database. *)
+(* [config db_name] store all values in the given IndexedDB database. *)
 val config : string -> Irmin.config
 
-module AO: Irmin.AO_MAKER
-module RW (K: Irmin.Hum.S) (V: Irmin.Hash.S): sig
-  include Irmin.RRW with type key = K.t and type value = V.t
-  val create: Irmin.config -> t Lwt.t
-end
 module Make (C: Irmin.Contents.S) (R: Irmin.Ref.S) (H: Irmin.Hash.S) : sig
   include Irmin.S
     with type key = C.Path.t

--- a/lib/irmin_IDB.mli
+++ b/lib/irmin_IDB.mli
@@ -11,4 +11,16 @@ module RW (K: Irmin.Hum.S) (V: Irmin.Hash.S): sig
   include Irmin.RRW with type key = K.t and type value = V.t
   val create: Irmin.config -> t Lwt.t
 end
-module Make: Irmin.S_MAKER
+module Make (C: Irmin.Contents.S) (R: Irmin.Ref.S) (H: Irmin.Hash.S) : sig
+  include Irmin.S
+    with type key = C.Path.t
+     and module Key = C.Path
+     and type value = C.t
+     and type branch_id = R.t
+     and type commit_id = H.t
+
+  val create_full: log:(string -> unit) -> Irmin.config -> Repo.t Lwt.t
+  (** [create_full ~log config] is like [Repo.create] but if a database
+      migration is required, it writes progress messages to [log] rather than
+      to the console. *)
+end

--- a/lib/irmin_IDB.mli
+++ b/lib/irmin_IDB.mli
@@ -7,5 +7,8 @@
 val config : string -> Irmin.config
 
 module AO: Irmin.AO_MAKER
-module RW: Irmin.RW_MAKER
+module RW (K: Irmin.Hum.S) (V: Irmin.Hash.S): sig
+  include Irmin.RRW with type key = K.t and type value = V.t
+  val create: Irmin.config -> t Lwt.t
+end
 module Make: Irmin.S_MAKER

--- a/test/test.ml
+++ b/test/test.ml
@@ -84,7 +84,7 @@ let start main =
 
       print "Dumping DB contents...";
 
-      Iridb_lwt.make db_name ~version:2 ~init:(fun _ -> assert false) >>= fun db ->
+      Iridb_lwt.make db_name ~version:2 ~init:(fun ~old_version:_ _ -> assert false) >>= fun db ->
       dump_bindings db "ao" >>= fun () ->
       dump_bindings db "rw" >|= fun () ->
       Iridb_lwt.close db
@@ -92,7 +92,9 @@ let start main =
 
     print "Testing ability to read v1 format db";
     begin
-      let init upgrader =
+      print "Importing old db dump...";
+      let init ~old_version upgrader =
+        assert (old_version = 0);
         Iridb_lwt.(create_store upgrader (store_name "ao"));
         Iridb_lwt.(create_store upgrader (store_name "rw")) in
       Iridb_lwt.make upgrade_db_name ~version:2 ~init >>= fun db ->
@@ -100,6 +102,7 @@ let start main =
       load_bindings db "rw" V1_db.rw >>= fun () ->
       Iridb_lwt.close db;
 
+      print "Opening old db...";
       let config = Irmin_IDB.config upgrade_db_name in
       I.Repo.create config >>= fun up_repo ->
       I.master make_task up_repo >>= fun up_store ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -104,7 +104,7 @@ let start main =
 
       print "Opening old db...";
       let config = Irmin_IDB.config upgrade_db_name in
-      I.Repo.create config >>= fun up_repo ->
+      I.create_full ~log:(print "%s") config >>= fun up_repo ->
       I.master make_task up_repo >>= fun up_store ->
       let up_store = up_store "test" in
       I.read_exn up_store key >>= expect_str "value2" >>= fun () ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -76,7 +76,7 @@ let start main =
       | None -> assert false
       | Some head ->
       print "Head: %s" (Irmin.Hash.SHA1.to_hum head);
-      I.update store key "value2" >>= fun () ->
+      I.update store key "value3" >>= fun () ->
       I.history store >>= fun hist ->
       I.History.iter_succ (fun head ->
         print "Parent: %s" (Irmin.Hash.SHA1.to_hum head)
@@ -84,9 +84,9 @@ let start main =
 
       print "Dumping DB contents...";
 
-      Iridb_lwt.make db_name ~version:2 ~init:(fun ~old_version:_ _ -> assert false) >>= fun db ->
-      dump_bindings db "ao" >>= fun () ->
-      dump_bindings db "rw" >|= fun () ->
+      Iridb_lwt.make db_name ~version:3 ~init:(fun ~old_version:_ _ -> assert false) >>= fun db ->
+      dump_bindings db "ao_git" >>= fun () ->
+      dump_bindings db "rw_git" >|= fun () ->
       Iridb_lwt.close db
     end >>= fun () ->
 
@@ -116,6 +116,14 @@ let start main =
       | Some head ->
       return (slice, head)
     end >>= fun (slice, head) ->
+
+    begin
+      Iridb_lwt.make upgrade_db_name ~version:3 ~init:(fun ~old_version:_ _ -> assert false) >>= fun db ->
+      dump_bindings db "ao" >>= fun () ->
+      dump_bindings db "ao_git" >>= fun () ->
+      dump_bindings db "rw" >>= fun () ->
+      dump_bindings db "rw_git"
+    end >>= fun () ->
 
     begin
       let config = Irmin_IDB.config import_db_name in


### PR DESCRIPTION
This will allow upgrading to newer versions of Irmin, which can't read the old 0.10 format. If irmin-indexeddb detects an old-format store, it will migrate the data to the new format. It puts the new data in
new `ao_git` and `rw_git` stores, but leaves the old data in `ao` and `rw` in case the migration goes wrong.