### PR TITLE
Add onabort handler for rw transactions

### DIFF
--- a/lib/js_api.ml
+++ b/lib/js_api.ml
@@ -73,6 +73,7 @@ end
 class type transaction = object
   method oncomplete : ('self Js.t, completeEvent Js.t) Dom.event_listener Js.prop
   method onerror : ('self Js.t, request errorEvent Js.t) Dom.event_listener Js.prop
+  method onabort : ('self Js.t, request errorEvent Js.t) Dom.event_listener Js.prop
   method objectStore : store_name -> objectStore Js.t Js.meth
   method abort : unit Js.meth
 end

--- a/lib/raw.ml
+++ b/lib/raw.ml
@@ -156,6 +156,10 @@ let trans_rw t setup =
     Lwt.wakeup_exn set_r (idb_error "RW" event);
     Js._true
   );
+  trans##.onabort := Dom.handler (fun event ->
+    Lwt.wakeup_exn set_r (idb_error "RW" event);
+    Js._true
+  );
   trans##.oncomplete := Dom.handler (fun _event ->
     Lwt.wakeup set_r ();
     Js._true


### PR DESCRIPTION
I added  the `onabort` callback to avoid blocking `Lwt` when the ` QuotaExceededError` fires :)