### PR TITLE
Upgrade to use Irmin 2.6 API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+Update to Irmin 1.6 API, which includes `clear` functions for emptying both the
+raw contents and branch stores.
+
 ## v2.0
 
 Update to Irmin 2.0 API. This way that stores are constructed has changed in Irmin 2.0.

--- a/irmin-indexeddb.opam
+++ b/irmin-indexeddb.opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.5.0"}
   "dune" {>= "1.11"}
   "base64" {>= "3.0.0"}
-  "irmin" {>= "2.0.0"}
+  "irmin" {>= "2.6.0"}
   "irmin-git" {with-test}
   "cstruct" {>= "1.7.0"}
   "js_of_ocaml" {>= "3.0"}

--- a/lib/branch_store.ml
+++ b/lib/branch_store.ml
@@ -38,11 +38,14 @@ module Make (K: Irmin.Type.S) (V: Irmin.Type.S) = struct
     let r = Raw.store idb Config.rw in
     { watch; r; prefix; notifications; listener = None }
 
-  let string_of_hash = Irmin.Type.to_bin_string V.t
-  let hash_of_string x =
-    match Irmin.Type.of_bin_string V.t x with
-    | Ok x -> x
-    | Error (`Msg m) -> failwith m
+  let string_of_hash = Irmin.Type.(unstage (to_bin_string V.t))
+
+  let hash_of_string =
+    let value_of_string = Irmin.Type.(unstage (of_bin_string V.t)) in
+    fun x ->
+      match value_of_string x with
+      | Ok x -> x
+      | Error (`Msg m) -> failwith m
 
   let find t k =
     Raw.get t.r (string_of_key k) >|= function
@@ -124,6 +127,11 @@ module Make (K: Irmin.Type.S) (V: Irmin.Type.S) = struct
   let watch_key t key ?init cb =
     ref_listener t;
     W.watch_key t.watch key ?init cb
+
+  let clear t =
+    list t >>= fun keys ->
+    Raw.clear t.r >>= fun () ->
+    Lwt_list.iter_s (fun k -> notify t k None) keys
 
   let close _ = Lwt.return_unit
 end

--- a/lib/content_store.ml
+++ b/lib/content_store.ml
@@ -10,12 +10,14 @@ module Make (K : Irmin.Hash.S) (V : Irmin.Type.S) = struct
 
   let string_of_hash = Irmin.Type.to_string K.t
 
-  let value_of_string s =
-    match Irmin.Type.of_bin_string V.t s with
-    | Ok x -> x
-    | Error (`Msg m) -> failwith m
+  let value_of_string =
+    let value_of_string = Irmin.Type.(unstage (of_bin_string V.t)) in
+    fun s ->
+      match value_of_string s with
+      | Ok x -> x
+      | Error (`Msg m) -> failwith m
 
-  let string_of_value = Irmin.Type.to_bin_string V.t
+  let string_of_value = Irmin.Type.(unstage (to_bin_string V.t))
 
   let find t k =
     Raw.get t (string_of_hash k) >|= function
@@ -37,6 +39,8 @@ module Make (K : Irmin.Hash.S) (V : Irmin.Type.S) = struct
     Raw.set t (string_of_hash k) value >|= fun () -> k
 
   let batch t fn = fn t
+
+  let clear t = Raw.clear t
 
   let close _ = Lwt.return_unit
 

--- a/lib/js_api.ml
+++ b/lib/js_api.ml
@@ -66,6 +66,7 @@ class type objectStore = object
   method add : value -> key -> request Js.t Js.meth
   method put : value -> key -> request Js.t Js.meth
   method delete : key -> request Js.t Js.meth
+  method clear : unit -> request Js.t Js.meth
   method get : key -> getRequest Js.t Js.meth
   method openCursor : openCursorRequest Js.t Js.meth
 end

--- a/lib/raw.ml
+++ b/lib/raw.ml
@@ -196,6 +196,12 @@ let remove t key =
       store##delete (Js.string key) |> ignore
     )
 
+let clear t =
+  trans_rw t
+    (fun store ->
+      store##clear () |> ignore
+    )
+
 let get t key =
   trans_ro t
     (fun store set_r ->

--- a/lib/raw.mli
+++ b/lib/raw.mli
@@ -34,4 +34,5 @@ val compare_and_set : store -> key -> test:(string option -> bool) -> new_value:
  * This happens in a single atomic transaction. *)
 
 val remove : store -> key -> unit Lwt.t
+val clear : store -> unit Lwt.t
 val bindings : store -> (key * string) list Lwt.t


### PR DESCRIPTION
Changes are as follows:

- provide `clear` operations for the raw stores (via a binding to `IDBObjectStore.clear`);
- fix usages of `Irmin.Type` generic functions to be properly staged.