### PR TITLE
Upgrade to use Irmin 2.6 API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## dev
+
+Update to Irmin 2.3 API, which includes `clear` functions for emptying both the
+raw contents and branch stores.
+
+`Content_store` has been split into `Content_store_git` and
+`Content_store_non_git`, as we now need to know whether to add the Git header
+when writing.
+
 ## v2.0
 
 Update to Irmin 2.0 API. This way that stores are constructed has changed in Irmin 2.0.

--- a/README.md
+++ b/README.md
@@ -9,20 +9,13 @@ This is an Irmin backend that stores the data in the web-browser's IndexedDB sto
 Instructions
 ------------
 
-You'll need to pin a fixed version of `irmin-git` first:
-
-    opam pin add -yn irmin-git.2.0.0 https://github.com/talex5/irmin.git#2.0.0-cuekeeper
-
-Also, until https://github.com/mirage/encore/issues/13 is fixed, you'll need to link with
-[helpers.js](blob/master/test/helpers.js) to add a missing stub.
-
 You can create stores using either the standard Git format, or using Irmin's own format.
 For Git format (you'll need to add `irmin-git` as a dependency), use:
 
 ```ocaml
 (* A Git-format store. This data can be exported and used with the regular Git
    tools. It can also read data produced by older versions of irmin-indexeddb. *)
-module I = Irmin_git.Generic(Irmin_indexeddb.Content_store)(Irmin_indexeddb.Branch_store)
+module I = Irmin_git.Generic(Irmin_indexeddb.Content_store_git)(Irmin_indexeddb.Branch_store)
     (Irmin.Contents.String)(Irmin.Path.String_list)(Irmin.Branch.String)
 ```
 
@@ -32,19 +25,18 @@ For Irmin format, use:
 (* An Irmin-format store. This allows storing custom metadata or using
    different hash functions, but is not compatible with the Git tools or with
    databases created by older versions of irmin-indexeddb. *)
-module I = Irmin.Make(Irmin_indexeddb.Content_store)(Irmin_indexeddb.Branch_store)
-    (Irmin.Metadata.None)(Irmin.Contents.String)
-    (Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA256)
+module I = Irmin.Make(Irmin_indexeddb.Content_store_non_git)(Irmin_indexeddb.Branch_store)
+    (Irmin.Metadata.None)(Irmin.Contents.String)(Irmin.Path.String_list)(Irmin.Branch.String)(Irmin.Hash.SHA256)
 ```
 
 To create a store, use e.g.
 
     let () =
-      let config = Irmin_IDB.config "MyProg" in
+      let config = Irmin_indexeddb.config "MyProg" in
       I.v config make_task >>= fun store ->
       ...
 
-The argument to `Irmin_IDB.config` is the name of the database to use (default "Irmin").
+The argument to `Irmin_indexeddb.config` is the name of the database to use.
 
 Note: In order to provide notifications (to instances running in other tabs),
 the backend will also write the current branch head hash into HTML local
@@ -69,4 +61,4 @@ Conditions
 See [LICENSE.md](LICENSE.md).
 
 
-[mirage]: http://openmirage.org/
+[mirage]: https://mirage.io

--- a/irmin-indexeddb.opam
+++ b/irmin-indexeddb.opam
@@ -7,10 +7,10 @@ license: "ISC"
 homepage: "https://github.com/talex5/irmin-indexeddb"
 bug-reports: "https://github.com/talex5/irmin-indexeddb/issues"
 depends: [
-  "ocaml" {>= "4.5.0"}
+  "ocaml" {>= "4.8.0"}
   "dune" {>= "1.11"}
   "base64" {>= "3.0.0"}
-  "irmin" {>= "2.2.0" & < "2.3.0"}
+  "irmin" {>= "2.6.0" & < "3.0.0"}
   "irmin-git" {with-test}
   "cstruct" {>= "1.7.0"}
   "fmt" {>= "0.8.7"}

--- a/lib/branch_store.ml
+++ b/lib/branch_store.ml
@@ -38,11 +38,14 @@ module Make (K: Irmin.Type.S) (V: Irmin.Type.S) = struct
     let r = Raw.store idb Config.rw in
     { watch; r; prefix; notifications; listener = None }
 
-  let string_of_hash = Irmin.Type.to_bin_string V.t
-  let hash_of_string x =
-    match Irmin.Type.of_bin_string V.t x with
-    | Ok x -> x
-    | Error (`Msg m) -> failwith m
+  let string_of_hash = Irmin.Type.(unstage (to_bin_string V.t))
+
+  let hash_of_string =
+    let value_of_string = Irmin.Type.(unstage (of_bin_string V.t)) in
+    fun x ->
+      match value_of_string x with
+      | Ok x -> x
+      | Error (`Msg m) -> failwith m
 
   let find t k =
     Raw.get t.r (string_of_key k) >|= function
@@ -124,6 +127,11 @@ module Make (K: Irmin.Type.S) (V: Irmin.Type.S) = struct
   let watch_key t key ?init cb =
     ref_listener t;
     W.watch_key t.watch key ?init cb
+
+  let clear t =
+    list t >>= fun keys ->
+    Raw.clear t.r >>= fun () ->
+    Lwt_list.iter_s (fun k -> notify t k None) keys
 
   let close _ = Lwt.return_unit
 end

--- a/lib/content_store.ml
+++ b/lib/content_store.ml
@@ -10,12 +10,14 @@ module Make (K : Irmin.Hash.S) (V : Irmin.Type.S) = struct
 
   let string_of_hash = Irmin.Type.to_string K.t
 
-  let value_of_string s =
-    match Irmin.Type.of_bin_string V.t s with
-    | Ok x -> x
-    | Error (`Msg m) -> failwith m
+  let value_of_string =
+    let value_of_string = Irmin.Type.(unstage (of_bin_string V.t)) in
+    fun s ->
+      match value_of_string s with
+      | Ok x -> x
+      | Error (`Msg m) -> failwith m
 
-  let string_of_value = Irmin.Type.to_bin_string V.t
+  let string_of_value = Irmin.Type.(unstage (to_bin_string V.t))
 
   let find t k =
     Raw.get t (string_of_hash k) >|= function
@@ -37,6 +39,8 @@ module Make (K : Irmin.Hash.S) (V : Irmin.Type.S) = struct
     Raw.set t (string_of_hash k) value >|= fun () -> k
 
   let batch t fn = fn t
+
+  let clear t = Raw.clear t
 
   let close _ = Lwt.return_unit
 

--- a/lib/irmin_indexeddb.ml
+++ b/lib/irmin_indexeddb.ml
@@ -1,9 +1,12 @@
 (* Copyright (C) 2020, Thomas Leonard.
    See the README file for details. *)
 
-module Content_store = Content_store.Make
+module Content_store_non_git = Content_store.Make
 module Branch_store = Branch_store.Make
 module Raw = Raw
+
+module Content_store_git (K : Irmin.Hash.S) (V : Irmin.Type.S) =
+  Content_store_non_git (K) (struct type t = V.t let t = Irmin.Type.boxed V.t end)
 
 let config = Config.v
 

--- a/lib/irmin_indexeddb.mli
+++ b/lib/irmin_indexeddb.mli
@@ -7,8 +7,15 @@
 val config : string -> Irmin.config
 (** [config db_name] is a configuration that stores all values in the given IndexedDB database. *)
 
-module Content_store : Irmin.CONTENT_ADDRESSABLE_STORE_MAKER
-(** The content-addressable store stores blobs, trees and commits. *)
+module Content_store_git : Irmin.CONTENT_ADDRESSABLE_STORE_MAKER
+(** The content-addressable store stores blobs, trees and commits.
+    
+    This is for use with [Irmin_git] (it always writes boxed values with the Git header). *)
+
+module Content_store_non_git : Irmin.CONTENT_ADDRESSABLE_STORE_MAKER
+(** The content-addressable store stores blobs, trees and commits.
+
+    This is not for use with [Irmin_git], since it doesn't include the Git header. *)
 
 module Branch_store : Irmin.ATOMIC_WRITE_STORE_MAKER
 (** The branch store records the head commit hash for each branch. *)

--- a/lib/js_api.ml
+++ b/lib/js_api.ml
@@ -66,6 +66,7 @@ class type objectStore = object
   method add : value -> key -> request Js.t Js.meth
   method put : value -> key -> request Js.t Js.meth
   method delete : key -> request Js.t Js.meth
+  method clear : unit -> request Js.t Js.meth
   method get : key -> getRequest Js.t Js.meth
   method openCursor : openCursorRequest Js.t Js.meth
 end

--- a/lib/raw.ml
+++ b/lib/raw.ml
@@ -196,6 +196,12 @@ let remove t key =
       store##delete (Js.string key) |> ignore
     )
 
+let clear t =
+  trans_rw t
+    (fun store ->
+      store##clear () |> ignore
+    )
+
 let get t key =
   trans_ro t
     (fun store set_r ->

--- a/lib/raw.mli
+++ b/lib/raw.mli
@@ -34,4 +34,5 @@ val compare_and_set : store -> key -> test:(string option -> bool) -> new_value:
  * This happens in a single atomic transaction. *)
 
 val remove : store -> key -> unit Lwt.t
+val clear : store -> unit Lwt.t
 val bindings : store -> (key * string) list Lwt.t


### PR DESCRIPTION
- `Content_store` has been split into `Content_store_git` and `Content_store_non_git`, as we now need to know whether to add the Git header when writing.

- Provide `clear` operations for the raw stores (via a binding to `IDBObjectStore.clear`);

Based on #19 by @craigfe.

Note: this compiles with Irmin versions down to 2.3, but they suffer from https://github.com/mirage/irmin/issues/917.